### PR TITLE
Fix maintainer field issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,6 @@ Authors@R: person(given = "Joshua C.",
            role = c("aut", "cre"),
            email = "joshfjelstul@gmail.com",
            comment = c(ORCID = "0000-0002-9494-260X"))
-Maintainer: Joshua C. Fjelstul, Ph.D.
 Description: This package contains the Fjelstul English Football Database. The database football matches played in the Premier League and the English Football League from the inaugural season of the Football League (1888-89) through the most recent season (2021-22). The database contains 5 datasets: seasons, teams, matches, appearances (one observation per team per match), and standings (end-of-the-season league tables). 
 Date: 2023-01-19
 License: CC-BY-SA 4.0


### PR DESCRIPTION
This PR addresses #1 by removing the `Maintainer` line in the DESCRIPTION file. This line is redundant, since you have the roles of `aut` and `cre` already specified in the `Authors` vector. More information can be found in [chapter 10](https://r-pkgs.org/description.html#author-who-are-you)  in [R Packages Second Edition](https://r-pkgs.org/).